### PR TITLE
Use websockets library instead of websocket-client

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv
 from cryptography.hazmat.primitives import serialization
+import asyncio
 
 from clients import KalshiHttpClient, KalshiWebSocketClient, Environment
 
@@ -40,5 +41,4 @@ ws_client = KalshiWebSocketClient(
 )
 
 # Connect via WebSocket
-ws_client.connect()
-ws_client.subscribe_to_tickers()
+asyncio.run(ws_client.connect())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ python-dateutil
 cryptography
 urllib3
 python-dotenv
-websocket-client
+websockets
 datetime


### PR DESCRIPTION
Replaces the websocket-client library with the [websockets](https://github.com/python-websockets/websockets) library.

Allows PROD environment to connect properly.

Fixes #1.