### PR TITLE
added supress_origin flag to work in prod

### DIFF
--- a/clients.py
+++ b/clients.py
@@ -198,7 +198,7 @@ class KalshiWebSocketClient(KalshiBaseClient):
             on_error=self.on_error,
             on_close=self.on_close
         )
-        self.ws.run_forever()
+        self.ws.run_forever(suppress_origin=True)
 
     def on_open(self, ws):
         """Callback when WebSocket connection is opened."""


### PR DESCRIPTION
Fixes issue where attempts to connect to prod resulted in 403s. **added suppress_origin=True** fixes the issue as outlined in this PR:
https://github.com/websocket-client/websocket-client/issues/489 