### PR TITLE
Updated README.md: example.py -> main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Example python code for accessing api-authenticated endpoints on [Kalshi](https://kalshi.com). This is not an SDK. 
 
 ## Installation 
-Install requirements.txt in a virtual enviornment of your choice and execute example.py from within the repo. 
+Install requirements.txt in a virtual environment of your choice and execute main.py from within the repo.


### PR DESCRIPTION
README.md makes a reference to a non-existent _example.py_. 